### PR TITLE
ccnl-riot: add includes for ccnl-cs

### DIFF
--- a/src/ccnl-riot/CMakeLists.txt
+++ b/src/ccnl-riot/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ccnl-riot)
  
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
-include_directories(include ../ccnl-core/include ../ccnl-pkt/include ../ccnl-fwd/include ../ccnl-unix/include ../ccnl-utils/include)
+include_directories(include ../ccnl-core/include ../ccnl-pkt/include ../ccnl-fwd/include ../ccnl-unix/include ../ccnl-utils/include ../ccnl-cs/include)
  
 file(GLOB SOURCES "src/*.c")
 file(GLOB HEADERS "include/*.h")


### PR DESCRIPTION
add includes for ccnl-riot